### PR TITLE
Fix font-awesome import issue

### DIFF
--- a/app/assets/partials/user-detail.html
+++ b/app/assets/partials/user-detail.html
@@ -23,8 +23,10 @@
         <span ng-show="user.is_captain">
           <img class="icon2" alt="Captain" title="Captain!" src="/assets/star_icon.png">
         </span>
-         {{getFullName(user)}}
-         <a ng-href="/users/{{user.id}}/edit"><i ng-show="canEdit" class="icon-pencil"></i></a>
+          {{getFullName(user)}}
+          <a ng-href="/users/{{user.id}}/edit">
+            <i ng-show="canEdit" class="icon-pencil"></i>
+          </a>
       </h2>
 
       <div>

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -94,15 +94,14 @@ form label{
 @iconWhiteSpritePath: asset-path('twitter/bootstrap/glyphicons-halflings-white.png');
 
 // Set the Font Awesome (Font Awesome is default. You can disable by commenting below lines)
-// Note: If you use asset_path() here, your compiled boostrap_and_overrides.css will not 
-//       have the proper paths. So for now we use the absolute path.
-/*@fontAwesomeEotPath: '/assets/fontawesome-webfont.eot';
-@fontAwesomeWoffPath: '/assets/fontawesome-webfont.woff';
-@fontAwesomeTtfPath: '/assets/fontawesome-webfont.ttf';
-@fontAwesomeSvgPath: '/assets/fontawesome-webfont.svg';
+@fontAwesomeEotPath: asset-url("fontawesome-webfont.eot");
+@fontAwesomeEotPath_iefix: asset-url("fontawesome-webfont.eot#iefix");
+@fontAwesomeWoffPath: asset-url("fontawesome-webfont.woff");
+@fontAwesomeTtfPath: asset-url("fontawesome-webfont.ttf");
+@fontAwesomeSvgPath: asset-url("fontawesome-webfont.svg#fontawesomeregular");
 
 // Font Awesome
-@import "fontawesome";*/
+@import "fontawesome/font-awesome";
 
 // Your custom LESS stylesheets goes here
 //


### PR DESCRIPTION
I believe this was caused by a versioning issue in the twitter-bootstrap-rails gem: https://github.com/seyhunak/twitter-bootstrap-rails/issues/593

Tested locally and icons have reappeared.
